### PR TITLE
feat!: verifySignature returns the parsed body and throws on invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,39 +2,35 @@
 
 ## [2.0.2](https://github.com/MONEI/monei-node-sdk/compare/v2.0.1...v2.0.2) (2026-05-26)
 
-
 ### Bug Fixes
 
-* regenerate from openapi v1.9.0 ([dd7c5f0](https://github.com/MONEI/monei-node-sdk/commit/dd7c5f08faa441fb1d382eed49502717a6b6e5a3))
+- regenerate from openapi v1.9.0 ([dd7c5f0](https://github.com/MONEI/monei-node-sdk/commit/dd7c5f08faa441fb1d382eed49502717a6b6e5a3))
 
 ## [2.0.1](https://github.com/MONEI/monei-node-sdk/compare/v2.0.0...v2.0.1) (2026-03-30)
 
-
 ### Bug Fixes
 
-* **changelog:** match angular preset sections and list style for 2.0.0 ([d7f1159](https://github.com/MONEI/monei-node-sdk/commit/d7f11594b106bf9bf02617574557bd90a00d2538))
-
+- **changelog:** match angular preset sections and list style for 2.0.0 ([d7f1159](https://github.com/MONEI/monei-node-sdk/commit/d7f11594b106bf9bf02617574557bd90a00d2538))
 
 ### Features
 
-* expose POSAuthTokenApi on Monei client ([d2fe1a1](https://github.com/MONEI/monei-node-sdk/commit/d2fe1a1aebb35babf68c766ac5bfe8cf6826a614))
+- expose POSAuthTokenApi on Monei client ([d2fe1a1](https://github.com/MONEI/monei-node-sdk/commit/d2fe1a1aebb35babf68c766ac5bfe8cf6826a614))
 
 # [2.0.0](https://github.com/MONEI/monei-node-sdk/compare/v1.9.1...v2.0.0) (2026-03-30)
 
-
 ### Bug Fixes
 
-* update release-it hook from yarn to pnpm ([738954b](https://github.com/MONEI/monei-node-sdk/commit/738954bc3c0d4eb299ab96e48cda585479162aa7))
+- update release-it hook from yarn to pnpm ([738954b](https://github.com/MONEI/monei-node-sdk/commit/738954bc3c0d4eb299ab96e48cda585479162aa7))
 
 ### Build System
 
-* migrate toolchain to Vite+ (`vite-plus`): `vp pack` (tsdown) replaces microbundle; `vp test` for Vitest; `vp check` (Oxlint/Oxfmt) replaces ESLint/Prettier; `vp config` and `.vite-hooks` replace Husky/lint-staged
-* switch package manager from Yarn Berry to pnpm (lockfile, scripts, CI)
-* raise Node baseline to 24 (`.nvmrc` and CI)
+- migrate toolchain to Vite+ (`vite-plus`): `vp pack` (tsdown) replaces microbundle; `vp test` for Vitest; `vp check` (Oxlint/Oxfmt) replaces ESLint/Prettier; `vp config` and `.vite-hooks` replace Husky/lint-staged
+- switch package manager from Yarn Berry to pnpm (lockfile, scripts, CI)
+- raise Node baseline to 24 (`.nvmrc` and CI)
 
 ### BREAKING CHANGES
 
-* build output and `package.json` `exports` use explicit `.mjs`/`.cjs` and `.d.mts`/`.d.cts`; confirm TypeScript `moduleResolution` and bundlers resolve these entrypoints (Node 18+ recommended)
+- build output and `package.json` `exports` use explicit `.mjs`/`.cjs` and `.d.mts`/`.d.cts`; confirm TypeScript `moduleResolution` and bundlers resolve these entrypoints (Node 18+ recommended)
 
 ## <small>1.9.1 (2026-01-21)</small>
 

--- a/index.ts
+++ b/index.ts
@@ -180,31 +180,42 @@ export class Monei {
   }
 
   /**
-   * Verify webhook signature to ensure the webhook was sent by MONEI
-   * @param body - Raw request body as string
-   * @param signature - Signature from the MONEI-Signature header
-   * @returns boolean indicating if the signature is valid
+   * Verify the `MONEI-Signature` header and return the parsed request body.
+   *
+   * The body is returned parsed as-is (not transformed). Its shape depends on
+   * the source, so no type is assumed: a payment `callbackUrl` sends the Payment
+   * object, while account webhooks send an event envelope `{ id, type, object,
+   * ... }` whose `object` varies by event (payment, subscription, etc.). Pass
+   * the expected type, e.g. `verifySignature<Payment>(body, signature)` for a
+   * payment callback.
+   *
+   * @param body - Raw request body as a string
+   * @param signature - Value of the `MONEI-Signature` header
+   * @returns The verified, parsed body (typed as `T`; `unknown` by default)
+   * @throws {ApiException} When the signature is missing, malformed, or invalid
    */
-  verifySignature(body: string, signature: string): boolean {
-    try {
-      const parts = signature.split(",").reduce<Record<string, string>>((result, part) => {
-        const [key, value] = part.split("=");
-        result[key] = value;
-        return result;
-      }, {});
+  verifySignature<T = unknown>(body: string, signature: string): T {
+    const parts = (signature || "").split(",").reduce<Record<string, string>>((result, part) => {
+      const [key, value] = part.split("=");
+      result[key] = value;
+      return result;
+    }, {});
 
-      if (!parts.t || !parts.v1) {
-        return false;
-      }
+    const hmac =
+      parts.t && parts.v1
+        ? crypto.createHmac("SHA256", this.apiKey).update(`${parts.t}.${body}`).digest("hex")
+        : null;
 
-      const hmac = crypto
-        .createHmac("SHA256", this.apiKey)
-        .update(`${parts.t}.${body}`)
-        .digest("hex");
-
-      return hmac === parts.v1;
-    } catch (error) {
-      return false;
+    if (!hmac || hmac !== parts.v1) {
+      throw new ApiException({
+        status: "ERROR",
+        statusCode: 401,
+        requestId: "",
+        message: "Signature verification failed",
+        requestTime: new Date().toISOString(),
+      });
     }
+
+    return JSON.parse(body) as T;
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -206,7 +206,12 @@ export class Monei {
         ? crypto.createHmac("SHA256", this.apiKey).update(`${parts.t}.${body}`).digest("hex")
         : null;
 
-    if (!hmac || hmac !== parts.v1) {
+    const valid =
+      hmac != null &&
+      hmac.length === parts.v1.length &&
+      crypto.timingSafeEqual(Buffer.from(hmac), Buffer.from(parts.v1));
+
+    if (!valid) {
       throw new ApiException({
         status: "ERROR",
         statusCode: 401,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,6 @@ overrides:
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest
 allowBuilds:
-  '@nestjs/core': true
-  '@openapitools/openapi-generator-cli': true
+  "@nestjs/core": true
+  "@openapitools/openapi-generator-cli": true
   esbuild: true

--- a/tests/monei-sdk.test.ts
+++ b/tests/monei-sdk.test.ts
@@ -144,31 +144,33 @@ describe("Monei SDK", () => {
   });
 
   describe("Signature Verification", () => {
-    it("should verify a valid signature", () => {
+    it("should verify a valid signature and return the parsed body", () => {
       const instance = new Monei(API_KEY);
       const body = JSON.stringify({ id: "test_id", amount: 1000 });
       const signature = genSig(body, API_KEY);
 
       const result = instance.verifySignature(body, signature);
-      expect(result).toBe(true);
+      expect(result).toEqual({ id: "test_id", amount: 1000 });
     });
 
-    it("should reject an invalid signature", () => {
+    it("should throw on an invalid signature", () => {
       const instance = new Monei(API_KEY);
       const body = JSON.stringify({ id: "test_id", amount: 1000 });
-      const invalidSignature = "v1=invalid_signature";
+      const invalidSignature = "t=123,v1=invalid_signature";
 
-      const result = instance.verifySignature(body, invalidSignature);
-      expect(result).toBe(false);
+      expect(() => instance.verifySignature(body, invalidSignature)).toThrow(
+        "Signature verification failed",
+      );
     });
 
-    it("should handle malformed signature format", () => {
+    it("should throw on a malformed signature format", () => {
       const instance = new Monei(API_KEY);
       const body = JSON.stringify({ id: "test_id", amount: 1000 });
       const malformedSignature = "invalid_format";
 
-      const result = instance.verifySignature(body, malformedSignature);
-      expect(result).toBe(false);
+      expect(() => instance.verifySignature(body, malformedSignature)).toThrow(
+        "Signature verification failed",
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

`verifySignature(body, signature)` currently returns a **`boolean`**, but the other SDKs and the docs treat it as returning the parsed request body:

| SDK | `verifySignature` |
| --- | --- |
| **Node** (current) | returns `boolean`, never throws |
| **PHP** | `return json_decode($body)` (parsed body), throws `ApiException` on mismatch |
| **Python** | returns the parsed object of the body, raises on mismatch |

Because of this, the documented Node usage was broken: `const payment = monei.verifySignature(...)` then `payment.status` — `payment` was a boolean, so `payment.status` was `undefined`, and an invalid signature returned `false` instead of being rejected (a silent security gap).

## Change

Align Node with PHP/Python:

```ts
verifySignature<T = unknown>(body: string, signature: string): T
```

- HMAC-verifies the `MONEI-Signature` header.
- **Throws `ApiException`** on a missing, malformed, or invalid signature (was: returns `false`).
- Returns `JSON.parse(body)` **as-is** (no transform).

### No default type — on purpose

The body shape differs by source, so assuming `Payment` would mislead:
- a payment **`callbackUrl`** sends the **Payment** object directly;
- account **webhooks** send an event envelope `{ id, type, object, ... }` whose `object` varies by event (payment, subscription, …).

Callers pass the type they expect, e.g. `verifySignature<Payment>(body, signature)` for a callback.

## Breaking change

`verifySignature` now returns the parsed body (was `boolean`) and throws on invalid signatures (was `false`). Major version bump.

## Notes

- Tests updated (valid → returns parsed body; invalid/malformed → throws). `tsc --noEmit` clean; `vp test run` green.
- The published docs currently document the old boolean behavior (updated to match the shipped SDK); they'll be switched back to the parsed-body form once this releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook signature verification now properly validates signatures, throws on invalid/malformed signatures, and returns the verified (parsed) request body with type-safe behavior.

* **Tests**
  * Signature verification tests updated to expect parsed response on success and thrown errors for invalid or malformed signatures.

* **Documentation**
  * Changelog formatting updated for recent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->